### PR TITLE
Remove warnings when build on OSX

### DIFF
--- a/arm_isa.cpp
+++ b/arm_isa.cpp
@@ -989,11 +989,7 @@ inline void B(arm_isa* ref, int h, int offset,
     s_extend = arm_isa::SignExtend((int32_t)(offset << 2), 26);
     mem_pos = (uint32_t)RB_read(PC) + 4 + s_extend;
     dprintf("Calculated branch destination: 0x%X\n", mem_pos);
-    if((mem_pos < 0)) {
-        fprintf(stderr, "Branch destination out of bounds\n");
-        exit(EXIT_FAILURE);
-        return;
-    } else RB_write(PC, mem_pos);
+    RB_write(PC, mem_pos);
 
     //fprintf(stderr, "0x%X\n", (unsigned int)mem_pos);
 

--- a/arm_isa_helper.H
+++ b/arm_isa_helper.H
@@ -228,6 +228,7 @@ unsigned bypass_read(unsigned address) {
       return RB.read(address);
     break;
   }
+  return ~((unsigned)0);
 }
 
 //! User defined macros to access a single bit


### PR DESCRIPTION
This PR has two non-related commits, but both remove warnings generated by default flags of Apple clang.

bypass_read function can reach the end of the function without returning a value. I force return 0xFFFF..., but we can choice other default value for this error.

mem_pos is an unsigned int, so it will never have a less than zero value. Why check it?
