### PR TITLE
Fixing Load Reg Halfword instruction (LDRH)

### DIFF
--- a/arm_isa.cpp
+++ b/arm_isa.cpp
@@ -1390,7 +1390,7 @@ void arm_isa::LDRSH(int rd, int rn){
   }
   // Verify coprocessor alignment
 
-  data = DATA_PORT->read(ls_address.entire);
+  data = MEM.read_half(ref->ls_address.entire);
   data &= 0xFFFF; /* Extracts halfword 
 		     BUG: Model must be little endian */
   data = arm_isa::SignExtend(data,16);

--- a/arm_isa.cpp
+++ b/arm_isa.cpp
@@ -1345,7 +1345,7 @@ void arm_isa::LDRH(int rd, int rn) {
     printf("Unpredictable LDRH instruction result (Address is not Halfword Aligned)\n");
     return;
   }
-  value = MEM.read_half(ref->ls_address.entire);
+  value = DATA_PORT->read_half(ref->ls_address.entire);
 
   RB_write(rd, value);
 
@@ -1388,7 +1388,7 @@ void arm_isa::LDRSH(int rd, int rn){
   }
   // Verify coprocessor alignment
 
-  data = MEM.read_half(ref->ls_address.entire);
+  data = DATA_PORT->read_half(ref->ls_address.entire);
   
   data = arm_isa::SignExtend(data,16);
   RB_write(rd, data);

--- a/arm_isa.cpp
+++ b/arm_isa.cpp
@@ -1345,7 +1345,7 @@ void arm_isa::LDRH(int rd, int rn) {
     printf("Unpredictable LDRH instruction result (Address is not Halfword Aligned)\n");
     return;
   }
-  value = DATA_PORT->read(ls_address.entire);
+  value = MEM.read_half(ref->ls_address.entire);
   value &= 0xFFFF; /* Zero extends halfword value 
 		      BUG: Model must be little endian in order to the code work  */
 

--- a/arm_isa.cpp
+++ b/arm_isa.cpp
@@ -1346,8 +1346,6 @@ void arm_isa::LDRH(int rd, int rn) {
     return;
   }
   value = MEM.read_half(ref->ls_address.entire);
-  value &= 0xFFFF; /* Zero extends halfword value 
-		      BUG: Model must be little endian in order to the code work  */
 
   RB_write(rd, value);
 
@@ -1391,8 +1389,7 @@ void arm_isa::LDRSH(int rd, int rn){
   // Verify coprocessor alignment
 
   data = MEM.read_half(ref->ls_address.entire);
-  data &= 0xFFFF; /* Extracts halfword 
-		     BUG: Model must be little endian */
+  
   data = arm_isa::SignExtend(data,16);
   RB_write(rd, data);
 


### PR DESCRIPTION
A bug has emerged in the LDRH instruction in the simulator with cache.
